### PR TITLE
refactor metadata validation pipeline

### DIFF
--- a/src/main/java/com/acme/core/metadata/DefaultMetadataGuard.java
+++ b/src/main/java/com/acme/core/metadata/DefaultMetadataGuard.java
@@ -81,7 +81,14 @@ public class DefaultMetadataGuard implements MetadataGuard {
                 if(mf!=null){
                     if(val instanceof Map){ stack.push(val);}
                     else{
-                        ctx.putEnv(mf.value(), val);
+                        String name = mf.value();
+                        if("userId".equals(name)){
+                            ctx.setUserId(String.valueOf(val));
+                        }else if("operateSystem".equals(name) || "system".equals(name)){
+                            ctx.setOperateSystem(String.valueOf(val));
+                        }else if("prodId".equals(name) || "productCode".equals(name)){
+                            ctx.setProdId(String.valueOf(val));
+                        }
                         if(!isTerminalType(val)) stack.push(val);
                     }
                 }else{

--- a/src/main/java/com/acme/core/metadata/DefaultMetadataValidator.java
+++ b/src/main/java/com/acme/core/metadata/DefaultMetadataValidator.java
@@ -5,7 +5,6 @@ import com.acme.core.metadata.rule.ValidationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -175,26 +174,9 @@ public class DefaultMetadataValidator implements MetadataValidator {
      */
     private ValidationContext createOptimizedContext(MetadataGuard.Mode mode, MetadataCollectionUnit unit) {
         ValidationContext context = new ValidationContext(mode);
-        
-        // 批量添加环境变量，避免多次调用
-        Map<String, Object> envData = new HashMap<>();
-        envData.put("framework", "metadata-guard");
-        envData.put("version", "3.0");
-        
-        // 添加单元特有数据
-        if (unit.getUserId() != null) {
-            envData.put("userId", unit.getUserId());
-        }
-        if (unit.getOperateSystem() != null) {
-            envData.put("operateSystem", unit.getOperateSystem());
-        }
-        if (unit.getProdId() != null) {
-            envData.put("prodId", unit.getProdId());
-        }
-        
-        // 批量设置环境变量
-        envData.forEach(context::putEnv);
-        
+        context.setUserId(unit.getUserId());
+        context.setOperateSystem(unit.getOperateSystem());
+        context.setProdId(unit.getProdId());
         return context;
     }
     

--- a/src/main/java/com/acme/core/metadata/DefaultUnifiedMetadataValidator.java
+++ b/src/main/java/com/acme/core/metadata/DefaultUnifiedMetadataValidator.java
@@ -5,6 +5,7 @@ import com.acme.core.metadata.model.MetaDefinition;
 import com.acme.core.metadata.registry.MetadataRegistryService;
 import com.acme.core.metadata.rule.ValidationContext;
 import com.acme.core.metadata.rule.ValidationPipeline;
+import com.acme.core.metadata.rule.ValidationUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,16 +112,17 @@ public class DefaultUnifiedMetadataValidator implements UnifiedMetadataValidator
     private void validateKeyValues(Map<String, Object> kvs, ValidationContext context) throws MetaViolationException {
         Map<String, MetaDefinition> defs = registry.getAll();
         ValidationPipeline pipe = ValidationPipeline.instance();
-        
+
         for (Map.Entry<String, Object> entry : kvs.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
             MetaDefinition def = defs.get(key);
-            
+
             // 检查元数据中心的监控模式配置，优先级高于接口级配置
             ValidationContext actualContext = resolveValidationMode(context, def);
-            
-            pipe.validate(key, value, def, actualContext);
+
+            ValidationUnit unit = new ValidationUnit(key, value, def, actualContext);
+            pipe.validate(unit);
         }
     }
     

--- a/src/main/java/com/acme/core/metadata/model/MetaDefinition.java
+++ b/src/main/java/com/acme/core/metadata/model/MetaDefinition.java
@@ -13,6 +13,8 @@ public class MetaDefinition {
     private Boolean grayEnabled;
     private Integer grayRatio;
     private MetadataGuard.Mode validationMode; // 元数据中心级的监控模式配置
+    private String productCode; // 参数中心配置的产品码
+    private String changeSystem; // 参数中心配置的变更系统
     // getters and setters
     public String getKey(){return key;}
     public void setKey(String k){ this.key = k;}
@@ -28,4 +30,8 @@ public class MetaDefinition {
     public void setGrayRatio(Integer r){ this.grayRatio = r;}
     public MetadataGuard.Mode getValidationMode(){return validationMode;}
     public void setValidationMode(MetadataGuard.Mode mode){ this.validationMode = mode;}
+    public String getProductCode(){return productCode;}
+    public void setProductCode(String p){ this.productCode = p;}
+    public String getChangeSystem(){return changeSystem;}
+    public void setChangeSystem(String s){ this.changeSystem = s;}
 }

--- a/src/main/java/com/acme/core/metadata/registry/impl/DefaultMetadataRegistryService.java
+++ b/src/main/java/com/acme/core/metadata/registry/impl/DefaultMetadataRegistryService.java
@@ -29,8 +29,8 @@ public class DefaultMetadataRegistryService implements MetadataRegistryService {
         last.set(System.currentTimeMillis());
     }
     private List<MetaDefinition> mock(){
-        MetaDefinition age = new MetaDefinition(); age.setKey("age"); age.setValuePattern("0-120");
-        MetaDefinition vip = new MetaDefinition(); vip.setKey("vipLevel"); vip.setValuePattern("1,2,3,4,5");
+        MetaDefinition age = new MetaDefinition(); age.setKey("age"); age.setValuePattern("0-120"); age.setProductCode("P1"); age.setChangeSystem("pccp");
+        MetaDefinition vip = new MetaDefinition(); vip.setKey("vipLevel"); vip.setValuePattern("1,2,3,4,5"); vip.setProductCode("P1"); vip.setChangeSystem("pccp");
         MetaDefinition news = new MetaDefinition(); news.setKey("newsFlag"); news.setAfterTime(Instant.now().minus(Duration.ofDays(1)));
         MetaDefinition gray = new MetaDefinition(); gray.setKey("brokerId"); gray.setGrayEnabled(true); gray.setGrayRatio(20);
         return Arrays.asList(age,vip,news,gray);

--- a/src/main/java/com/acme/core/metadata/rule/MetaValidationRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/MetaValidationRule.java
@@ -2,9 +2,7 @@
 package com.acme.core.metadata.rule;
 
 import com.acme.core.metadata.MetaViolationException;
-import com.acme.core.metadata.model.MetaDefinition;
-
 public interface MetaValidationRule {
     int order();
-    void validate(String key,Object value, MetaDefinition def, ValidationContext ctx) throws MetaViolationException;
+    void validate(ValidationUnit unit) throws MetaViolationException;
 }

--- a/src/main/java/com/acme/core/metadata/rule/MetaValidationRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/MetaValidationRule.java
@@ -2,7 +2,11 @@
 package com.acme.core.metadata.rule;
 
 import com.acme.core.metadata.MetaViolationException;
+import java.util.Collections;
+import java.util.Set;
+
 public interface MetaValidationRule {
     int order();
     void validate(ValidationUnit unit) throws MetaViolationException;
+    default Set<String> fields(){ return Collections.emptySet(); }
 }

--- a/src/main/java/com/acme/core/metadata/rule/ValidationContext.java
+++ b/src/main/java/com/acme/core/metadata/rule/ValidationContext.java
@@ -7,30 +7,35 @@ import com.acme.core.metadata.metric.MetaViolationCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class ValidationContext {
     private static final Logger LOG = LoggerFactory.getLogger("MetaViolation");
     private final MetadataGuard.Mode mode;
-    private final Map<String,Object> env = new HashMap<>();
-    
+    private String userId;
+    private String operateSystem;
+    private String prodId;
+
     public ValidationContext(MetadataGuard.Mode mode){ this.mode = mode; }
     public MetadataGuard.Mode mode(){ return mode;}
-    public void putEnv(String k,Object v){ env.put(k,v);}
-    public <T> T env(String k){ return (T)env.get(k);}
-    public int envSize(){ return env.size();}
-    
+
+    public String userId(){ return userId; }
+    public void setUserId(String userId){ this.userId = userId; }
+    public String operateSystem(){ return operateSystem; }
+    public void setOperateSystem(String operateSystem){ this.operateSystem = operateSystem; }
+    public String prodId(){ return prodId; }
+    public void setProdId(String prodId){ this.prodId = prodId; }
+
     /**
      * 复制环境变量到当前上下文
      * @param source 源上下文
      */
     public void copyEnvFrom(ValidationContext source) {
-        if (source != null && source.env != null) {
-            this.env.putAll(source.env);
+        if (source != null) {
+            if(source.userId != null) this.userId = source.userId;
+            if(source.operateSystem != null) this.operateSystem = source.operateSystem;
+            if(source.prodId != null) this.prodId = source.prodId;
         }
     }
-    
+
     public void violate(String msg) throws MetaViolationException{
         if(mode==MetadataGuard.Mode.INTERCEPT){
             throw new MetaViolationException(msg);

--- a/src/main/java/com/acme/core/metadata/rule/ValidationPipeline.java
+++ b/src/main/java/com/acme/core/metadata/rule/ValidationPipeline.java
@@ -4,20 +4,33 @@ package com.acme.core.metadata.rule;
 import com.acme.core.metadata.MetaViolationException;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class ValidationPipeline {
     private static final List<MetaValidationRule> RULES;
+    private static final Map<String,List<MetaValidationRule>> FIELD_RULES;
     static{
         ServiceLoader<MetaValidationRule> loader = ServiceLoader.load(MetaValidationRule.class);
         List<MetaValidationRule> ls = new ArrayList<>();
-        loader.forEach(ls::add);
+        Map<String,List<MetaValidationRule>> map = new HashMap<>();
+        loader.forEach(r->{
+            ls.add(r);
+            for(String f: r.fields()){
+                map.computeIfAbsent(f,k->new ArrayList<>()).add(r);
+            }
+        });
         ls.sort(Comparator.comparingInt(MetaValidationRule::order));
         RULES = Collections.unmodifiableList(ls);
+        FIELD_RULES = Collections.unmodifiableMap(map.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,e->Collections.unmodifiableList(e.getValue()))));
     }
     public void validate(ValidationUnit unit) throws MetaViolationException{
         for(MetaValidationRule r: RULES){
             r.validate(unit);
         }
+    }
+    public List<MetaValidationRule> rulesForField(String field){
+        return FIELD_RULES.getOrDefault(field, Collections.emptyList());
     }
     private ValidationPipeline(){}
     private static class Holder{ private static final ValidationPipeline INST = new ValidationPipeline();}

--- a/src/main/java/com/acme/core/metadata/rule/ValidationPipeline.java
+++ b/src/main/java/com/acme/core/metadata/rule/ValidationPipeline.java
@@ -2,7 +2,6 @@
 package com.acme.core.metadata.rule;
 
 import com.acme.core.metadata.MetaViolationException;
-import com.acme.core.metadata.model.MetaDefinition;
 
 import java.util.*;
 
@@ -15,9 +14,9 @@ public class ValidationPipeline {
         ls.sort(Comparator.comparingInt(MetaValidationRule::order));
         RULES = Collections.unmodifiableList(ls);
     }
-    public void validate(String k,Object v, MetaDefinition def, ValidationContext ctx) throws MetaViolationException{
+    public void validate(ValidationUnit unit) throws MetaViolationException{
         for(MetaValidationRule r: RULES){
-            r.validate(k,v,def,ctx);
+            r.validate(unit);
         }
     }
     private ValidationPipeline(){}

--- a/src/main/java/com/acme/core/metadata/rule/ValidationUnit.java
+++ b/src/main/java/com/acme/core/metadata/rule/ValidationUnit.java
@@ -1,0 +1,25 @@
+package com.acme.core.metadata.rule;
+
+import com.acme.core.metadata.model.MetaDefinition;
+
+/**
+ * 封装单次校验所需的全部信息
+ */
+public class ValidationUnit {
+    private final String key;
+    private final Object value;
+    private final MetaDefinition definition;
+    private final ValidationContext context;
+
+    public ValidationUnit(String key, Object value, MetaDefinition definition, ValidationContext context) {
+        this.key = key;
+        this.value = value;
+        this.definition = definition;
+        this.context = context;
+    }
+
+    public String key() { return key; }
+    public Object value() { return value; }
+    public MetaDefinition definition() { return definition; }
+    public ValidationContext context() { return context; }
+}

--- a/src/main/java/com/acme/core/metadata/rule/impl/GrayRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/GrayRule.java
@@ -4,13 +4,16 @@ package com.acme.core.metadata.rule.impl;
 import com.acme.core.metadata.MetaViolationException;
 import com.acme.core.metadata.rule.MetaValidationRule;
 import com.acme.core.metadata.rule.ValidationUnit;
+import java.util.Collections;
+import java.util.Set;
 
 public class GrayRule implements MetaValidationRule {
     @Override public int order(){ return 24;}
+    @Override public Set<String> fields(){ return Collections.singleton("userId"); }
     @Override public void validate(ValidationUnit unit) throws MetaViolationException{
         if(unit.definition()==null || !Boolean.TRUE.equals(unit.definition().getGrayEnabled())) return;
         Integer ratio = unit.definition().getGrayRatio(); if(ratio==null||ratio<=0) return;
-        String uid = String.valueOf(unit.context().env("userId"));
+        String uid = unit.context().userId();
         if(uid==null||uid.length()<2) return;
         int bucket = Integer.parseInt(uid.substring(uid.length()-2));
         if(bucket>=ratio) return; // 未命中灰度

--- a/src/main/java/com/acme/core/metadata/rule/impl/GrayRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/GrayRule.java
@@ -2,16 +2,15 @@
 package com.acme.core.metadata.rule.impl;
 
 import com.acme.core.metadata.MetaViolationException;
-import com.acme.core.metadata.model.MetaDefinition;
 import com.acme.core.metadata.rule.MetaValidationRule;
-import com.acme.core.metadata.rule.ValidationContext;
+import com.acme.core.metadata.rule.ValidationUnit;
 
 public class GrayRule implements MetaValidationRule {
     @Override public int order(){ return 24;}
-    @Override public void validate(String k,Object v, MetaDefinition d, ValidationContext ctx) throws MetaViolationException{
-        if(d==null || !Boolean.TRUE.equals(d.getGrayEnabled())) return;
-        Integer ratio = d.getGrayRatio(); if(ratio==null||ratio<=0) return;
-        String uid = String.valueOf(ctx.env("userId"));
+    @Override public void validate(ValidationUnit unit) throws MetaViolationException{
+        if(unit.definition()==null || !Boolean.TRUE.equals(unit.definition().getGrayEnabled())) return;
+        Integer ratio = unit.definition().getGrayRatio(); if(ratio==null||ratio<=0) return;
+        String uid = String.valueOf(unit.context().env("userId"));
         if(uid==null||uid.length()<2) return;
         int bucket = Integer.parseInt(uid.substring(uid.length()-2));
         if(bucket>=ratio) return; // 未命中灰度

--- a/src/main/java/com/acme/core/metadata/rule/impl/KeyPresenceRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/KeyPresenceRule.java
@@ -2,13 +2,12 @@
 package com.acme.core.metadata.rule.impl;
 
 import com.acme.core.metadata.MetaViolationException;
-import com.acme.core.metadata.model.MetaDefinition;
 import com.acme.core.metadata.rule.MetaValidationRule;
-import com.acme.core.metadata.rule.ValidationContext;
+import com.acme.core.metadata.rule.ValidationUnit;
 
 public class KeyPresenceRule implements MetaValidationRule {
     @Override public int order(){ return 10;}
-    @Override public void validate(String k,Object v, MetaDefinition d, ValidationContext ctx) throws MetaViolationException{
-        if(d==null){ ctx.violate("未知元数据键:"+k);}
+    @Override public void validate(ValidationUnit unit) throws MetaViolationException{
+        if(unit.definition()==null){ unit.context().violate("未知元数据键:"+unit.key());}
     }
 }

--- a/src/main/java/com/acme/core/metadata/rule/impl/ProductSystemMatchRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/ProductSystemMatchRule.java
@@ -3,6 +3,9 @@ package com.acme.core.metadata.rule.impl;
 import com.acme.core.metadata.MetaViolationException;
 import com.acme.core.metadata.rule.MetaValidationRule;
 import com.acme.core.metadata.rule.ValidationUnit;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * 检查产品码和变更系统是否与参数中心配置一致
@@ -10,22 +13,21 @@ import com.acme.core.metadata.rule.ValidationUnit;
 public class ProductSystemMatchRule implements MetaValidationRule {
     @Override
     public int order() { return 20; }
+    @Override public Set<String> fields(){ return new HashSet<>(Arrays.asList("prodId","operateSystem")); }
 
     @Override
     public void validate(ValidationUnit unit) throws MetaViolationException {
         if(unit.definition()==null) return;
         String expectedProd = unit.definition().getProductCode();
         if(expectedProd!=null){
-            String actual = unit.context().env("prodId");
-            if(actual==null){ actual = unit.context().env("productCode"); }
+            String actual = unit.context().prodId();
             if(actual!=null && !expectedProd.equals(actual)){
                 unit.context().violate("产品码不匹配:"+unit.key());
             }
         }
         String expectedSys = unit.definition().getChangeSystem();
         if(expectedSys!=null){
-            String actualSys = unit.context().env("operateSystem");
-            if(actualSys==null){ actualSys = unit.context().env("system"); }
+            String actualSys = unit.context().operateSystem();
             if(actualSys!=null && !expectedSys.equals(actualSys)){
                 unit.context().violate("变更系统不匹配:"+unit.key());
             }

--- a/src/main/java/com/acme/core/metadata/rule/impl/ProductSystemMatchRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/ProductSystemMatchRule.java
@@ -1,0 +1,34 @@
+package com.acme.core.metadata.rule.impl;
+
+import com.acme.core.metadata.MetaViolationException;
+import com.acme.core.metadata.rule.MetaValidationRule;
+import com.acme.core.metadata.rule.ValidationUnit;
+
+/**
+ * 检查产品码和变更系统是否与参数中心配置一致
+ */
+public class ProductSystemMatchRule implements MetaValidationRule {
+    @Override
+    public int order() { return 20; }
+
+    @Override
+    public void validate(ValidationUnit unit) throws MetaViolationException {
+        if(unit.definition()==null) return;
+        String expectedProd = unit.definition().getProductCode();
+        if(expectedProd!=null){
+            String actual = unit.context().env("prodId");
+            if(actual==null){ actual = unit.context().env("productCode"); }
+            if(actual!=null && !expectedProd.equals(actual)){
+                unit.context().violate("产品码不匹配:"+unit.key());
+            }
+        }
+        String expectedSys = unit.definition().getChangeSystem();
+        if(expectedSys!=null){
+            String actualSys = unit.context().env("operateSystem");
+            if(actualSys==null){ actualSys = unit.context().env("system"); }
+            if(actualSys!=null && !expectedSys.equals(actualSys)){
+                unit.context().violate("变更系统不匹配:"+unit.key());
+            }
+        }
+    }
+}

--- a/src/main/java/com/acme/core/metadata/rule/impl/ValueRangeRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/ValueRangeRule.java
@@ -2,29 +2,28 @@
 package com.acme.core.metadata.rule.impl;
 
 import com.acme.core.metadata.MetaViolationException;
-import com.acme.core.metadata.model.MetaDefinition;
 import com.acme.core.metadata.rule.MetaValidationRule;
-import com.acme.core.metadata.rule.ValidationContext;
+import com.acme.core.metadata.rule.ValidationUnit;
 
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
 public class ValueRangeRule implements MetaValidationRule {
     @Override public int order(){ return 30;}
-    @Override public void validate(String k,Object v, MetaDefinition d, ValidationContext ctx) throws MetaViolationException{
-        if(d==null || d.getValuePattern()==null || v==null) return;
-        String pat = d.getValuePattern();
-        String val = String.valueOf(v);
+    @Override public void validate(ValidationUnit unit) throws MetaViolationException{
+        if(unit.definition()==null || unit.definition().getValuePattern()==null || unit.value()==null) return;
+        String pat = unit.definition().getValuePattern();
+        String val = String.valueOf(unit.value());
         if(pat.contains(",")){
-            if(!Arrays.asList(pat.split(",")).contains(val)){ ctx.violate("值["+val+"]不在集合:"+pat);}
+            if(!Arrays.asList(pat.split(",")).contains(val)){ unit.context().violate("值["+val+"]不在集合:"+pat);}
         }else if(pat.contains("-")){
             String[] p=pat.split("-"); try{
                 long low=Long.parseLong(p[0].trim()), hi=Long.parseLong(p[1].trim()), num=Long.parseLong(val);
-                if(num<low||num>hi){ ctx.violate("值["+val+"]不在区间:"+pat);}
+                if(num<low||num>hi){ unit.context().violate("值["+val+"]不在区间:"+pat);}
             }catch(NumberFormatException ignore){}
         }else if(pat.startsWith("/")&&pat.endsWith("/")){
             Pattern r = Pattern.compile(pat.substring(1,pat.length()-1));
-            if(!r.matcher(val).matches()){ ctx.violate("值["+val+"]不匹配正则:"+pat);}
+            if(!r.matcher(val).matches()){ unit.context().violate("值["+val+"]不匹配正则:"+pat);}
         }
     }
 }

--- a/src/main/java/com/acme/core/metadata/rule/impl/ValueRangeRule.java
+++ b/src/main/java/com/acme/core/metadata/rule/impl/ValueRangeRule.java
@@ -4,12 +4,15 @@ package com.acme.core.metadata.rule.impl;
 import com.acme.core.metadata.MetaViolationException;
 import com.acme.core.metadata.rule.MetaValidationRule;
 import com.acme.core.metadata.rule.ValidationUnit;
+import java.util.Collections;
+import java.util.Set;
 
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
 public class ValueRangeRule implements MetaValidationRule {
     @Override public int order(){ return 30;}
+    @Override public Set<String> fields(){ return Collections.singleton("*"); }
     @Override public void validate(ValidationUnit unit) throws MetaViolationException{
         if(unit.definition()==null || unit.definition().getValuePattern()==null || unit.value()==null) return;
         String pat = unit.definition().getValuePattern();

--- a/src/main/resources/META-INF/services/com.acme.core.metadata.rule.MetaValidationRule
+++ b/src/main/resources/META-INF/services/com.acme.core.metadata.rule.MetaValidationRule
@@ -2,3 +2,4 @@
 com.acme.core.metadata.rule.impl.KeyPresenceRule
 com.acme.core.metadata.rule.impl.GrayRule
 com.acme.core.metadata.rule.impl.ValueRangeRule
+com.acme.core.metadata.rule.impl.ProductSystemMatchRule

--- a/src/test/java/com/acme/core/metadata/UnifiedMetadataValidatorTest.java
+++ b/src/test/java/com/acme/core/metadata/UnifiedMetadataValidatorTest.java
@@ -80,7 +80,7 @@ class UnifiedMetadataValidatorTest {
     void testValidationModeResolution() {
         // 测试监控模式解析（接口级配置）
         ValidationContext interceptContext = new ValidationContext(MetadataGuard.Mode.INTERCEPT);
-        interceptContext.putEnv("userId", "12345");
+        interceptContext.setUserId("12345");
         
         Map<String, Object> data = new HashMap<>();
         data.put("test", "value");


### PR DESCRIPTION
## Summary
- refactor validation rules to operate on a new `ValidationUnit`
- support metadata center mode override when validating
- add pluggable product/system match rule and register via service loader

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f43353d408324bfb31a1f90577b2b